### PR TITLE
basepage: backtrack up the DOM from the first image to insert ajax results

### DIFF
--- a/basepage.html
+++ b/basepage.html
@@ -73,8 +73,9 @@ $(document).ready(function() {
       && target.substring(0,1) != '_' // does not begin with a _
       && target.indexOf('.') != -1  // contains a . in it
     ) {
-      $('table:eq(0)').find("td:eq(9) div:eq(0)").append('<div id="traceroute"></div>');  // create the div
-      $('#traceroute').load('traceping.cgi?target=' + target);              // replace the div with the traceroute!
+      var traceroute_container = $('<div></div>');
+      $('div img:eq(0)').parent().parent().append(traceroute_container);
+      traceroute_container.load('traceping.cgi?target=' + target);
     }
 });
 //]]>


### PR DESCRIPTION
The previous approach was to use a series of table cell offsets, which results in undefined
behaviour depending on the implementation of the DOM.  Instead, search for the first `<img>`
tag that is contained by a `<div>` and then backtrack upwards to the `<div>` in order to find the
proper insertion point.

Tested-on: IE 6, IE 10, Chrome, Firefox, Opera 12.
Signed-off-by: William Pitcock kaniini@dereferenced.org.
