### PR TITLE
basepage: update jquery version to 2.0.3

### DIFF
--- a/basepage.html
+++ b/basepage.html
@@ -57,7 +57,7 @@ a.menulink:hover       {
 <script src="/smokeping/scriptaculous/scriptaculous.js?load=builder,effects,dragdrop" type="text/javascript"></script>
 <script src="/smokeping/cropper/cropper.js" type="text/javascript"></script>
 <script src="/smokeping/smokeping-zoom.js" type="text/javascript"></script>
-<script src="//ajax.googleapis.com/ajax/libs/jquery/1/jquery.min.js"></script>
+<script src="//ajax.googleapis.com/ajax/libs/jquery/2.0.3/jquery.min.js"></script>
 
 <script type="text/javascript">
 //<![CDATA[


### PR DESCRIPTION
The jQuery used by traceping uses an outdated jQuery version (1.0) which throws deprecation warnings
on the web console when used with Firefox 25.  We upgrade the used version to jQuery 2.0.3 which is
the most recent version at the time of writing.

Signed-off-by: William Pitcock kaniini@dereferenced.org.
